### PR TITLE
Add brick block objects

### DIFF
--- a/MarioGame.yyp
+++ b/MarioGame.yyp
@@ -86,6 +86,8 @@
     {"id":{"name":"spr_smario_jump","path":"sprites/spr_smario_jump/spr_smario_jump.yy",},},
     {"id":{"name":"spr_block_solid","path":"sprites/spr_block_solid/spr_block_solid.yy",},},
     {"id":{"name":"Solid","path":"objects/Solid/Solid.yy",},},
+    {"id":{"name":"BrickBase","path":"objects/BrickBase/BrickBase.yy",},},
+    {"id":{"name":"BrickBlock","path":"objects/BrickBlock/BrickBlock.yy",},},
     {"id":{"name":"Sprite31","path":"sprites/Sprite31/Sprite31.yy",},},
     {"id":{"name":"EnemyStompable","path":"objects/EnemyStompable/EnemyStompable.yy",},},
     {"id":{"name":"EnemyIntouchable","path":"objects/EnemyIntouchable/EnemyIntouchable.yy",},},

--- a/objects/BrickBase/BrickBase.yy
+++ b/objects/BrickBase/BrickBase.yy
@@ -1,0 +1,37 @@
+{
+  "resourceType": "GMObject",
+  "resourceVersion": "1.0",
+  "name": "BrickBase",
+  "eventList": [
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,}
+  ],
+  "managed": true,
+  "overriddenProperties": [],
+  "parent": {
+    "name": "Objetos",
+    "path": "folders/Objetos.yy"
+  },
+  "parentObjectId": {
+    "name": "Solid",
+    "path": "objects/Solid/Solid.yy"
+  },
+  "persistent": false,
+  "physicsAngularDamping": 0.1,
+  "physicsDensity": 0.5,
+  "physicsFriction": 0.2,
+  "physicsGroup": 1,
+  "physicsKinematic": false,
+  "physicsLinearDamping": 0.1,
+  "physicsObject": false,
+  "physicsRestitution": 0.1,
+  "physicsSensor": false,
+  "physicsShape": 1,
+  "physicsShapePoints": [],
+  "physicsStartAwake": true,
+  "properties": [],
+  "solid": false,
+  "spriteId": null,
+  "spriteMaskId": null,
+  "visible": true
+}

--- a/objects/BrickBase/Create_0.gml
+++ b/objects/BrickBase/Create_0.gml
@@ -1,0 +1,12 @@
+// Variables base para bricks
+startY = y;
+bounce_offset = 0;
+bounce_speed = 1;
+bounce_height = 4;
+bounce_dir = 0; // 0=idle, -1=subiendo, 1=bajando
+is_hit = false;
+
+// Función que se llamará cuando el ladrillo sea golpeado
+onHit = function(_player) {
+    // Se puede sobrescribir en objetos hijos
+};

--- a/objects/BrickBase/Step_0.gml
+++ b/objects/BrickBase/Step_0.gml
@@ -1,0 +1,21 @@
+// Detectar golpe desde abajo
+if (!is_hit) {
+    var _p = instance_place(x, y + sprite_height, Player);
+    if (_p != noone && _p.vsp < 0) {
+        is_hit = true;
+        bounce_dir = -1;
+        onHit(_p);
+    }
+} else {
+    // Animación de rebote
+    bounce_offset += bounce_dir * bounce_speed;
+    y = startY + bounce_offset;
+    if (bounce_dir == -1 && bounce_offset <= -bounce_height) {
+        bounce_dir = 1;
+    } else if (bounce_dir == 1 && bounce_offset >= 0) {
+        bounce_dir = 0;
+        bounce_offset = 0;
+        y = startY;
+        is_hit = false;
+    }
+}

--- a/objects/BrickBlock/BrickBlock.yy
+++ b/objects/BrickBlock/BrickBlock.yy
@@ -1,0 +1,41 @@
+{
+  "resourceType": "GMObject",
+  "resourceVersion": "1.0",
+  "name": "BrickBlock",
+  "eventList": [
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,}
+  ],
+  "managed": true,
+  "overriddenProperties": [],
+  "parent": {
+    "name": "Objetos",
+    "path": "folders/Objetos.yy"
+  },
+  "parentObjectId": {
+    "name": "BrickBase",
+    "path": "objects/BrickBase/BrickBase.yy"
+  },
+  "persistent": false,
+  "physicsAngularDamping": 0.1,
+  "physicsDensity": 0.5,
+  "physicsFriction": 0.2,
+  "physicsGroup": 1,
+  "physicsKinematic": false,
+  "physicsLinearDamping": 0.1,
+  "physicsObject": false,
+  "physicsRestitution": 0.1,
+  "physicsSensor": false,
+  "physicsShape": 1,
+  "physicsShapePoints": [],
+  "physicsStartAwake": true,
+  "properties": [],
+  "solid": false,
+  "spriteId": {
+    "name": "spr_block_brick",
+    "path": "sprites/spr_block_brick/spr_block_brick.yy"
+  },
+  "spriteMaskId": null,
+  "visible": true
+}

--- a/objects/BrickBlock/Create_0.gml
+++ b/objects/BrickBlock/Create_0.gml
@@ -1,0 +1,2 @@
+// Heredar comportamiento base
+event_inherited();

--- a/objects/BrickBlock/Draw_0.gml
+++ b/objects/BrickBlock/Draw_0.gml
@@ -1,0 +1,1 @@
+draw_self();

--- a/objects/BrickBlock/Step_0.gml
+++ b/objects/BrickBlock/Step_0.gml
@@ -1,0 +1,1 @@
+event_inherited();


### PR DESCRIPTION
## Summary
- add `BrickBase` object as a solid child and implement bounce logic
- add `BrickBlock` object inheriting from `BrickBase` using `spr_block_brick`
- register new brick block objects in `MarioGame.yyp`
- remove extra brick sprite files

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68611bdebe50832ebbc5dd37090ea28a