### PR TITLE
Add brick objects

### DIFF
--- a/objects/BlockBrick/BlockBrick.yy
+++ b/objects/BlockBrick/BlockBrick.yy
@@ -1,0 +1,40 @@
+{
+  "resourceType": "GMObject",
+  "resourceVersion": "1.0",
+  "name": "BlockBrick",
+  "eventList": [
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,}
+  ],
+  "managed": true,
+  "overriddenProperties": [],
+  "parent": {
+    "name": "Block",
+    "path": "folders/Objetos/Block.yy",
+  },
+  "parentObjectId": {
+    "name": "BrickBase",
+    "path": "objects/BrickBase/BrickBase.yy",
+  },
+  "persistent": false,
+  "physicsAngularDamping": 0.1,
+  "physicsDensity": 0.5,
+  "physicsFriction": 0.2,
+  "physicsGroup": 1,
+  "physicsKinematic": false,
+  "physicsLinearDamping": 0.1,
+  "physicsObject": false,
+  "physicsRestitution": 0.1,
+  "physicsSensor": false,
+  "physicsShape": 1,
+  "physicsShapePoints": [],
+  "physicsStartAwake": true,
+  "properties": [],
+  "solid": false,
+  "spriteId": {
+    "name": "spr_block_brick",
+    "path": "sprites/spr_block_brick/spr_block_brick.yy",
+  },
+  "spriteMaskId": null,
+  "visible": true,
+}

--- a/objects/BlockBrick/Create_0.gml
+++ b/objects/BlockBrick/Create_0.gml
@@ -1,0 +1,13 @@
+/// @description Configuracion inicial del ladrillo
+// Heredar configuracion base
+event_inherited();
+
+original_y = y;
+hit_speed = 0;
+
+// Sobrescribir la funcion onHit para producir un peque\xF1o rebote
+onHit = function() {
+    if (hit_speed == 0) {
+        hit_speed = -3;
+    }
+};

--- a/objects/BlockBrick/Step_0.gml
+++ b/objects/BlockBrick/Step_0.gml
@@ -1,0 +1,9 @@
+/// @description Maneja el rebote al ser golpeado
+if (hit_speed != 0) {
+    y += hit_speed;
+    hit_speed += 0.5;
+    if (y >= original_y) {
+        y = original_y;
+        hit_speed = 0;
+    }
+}

--- a/objects/BrickBase/BrickBase.yy
+++ b/objects/BrickBase/BrickBase.yy
@@ -1,0 +1,33 @@
+{
+  "resourceType": "GMObject",
+  "resourceVersion": "1.0",
+  "name": "BrickBase",
+  "eventList": [
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,}
+  ],
+  "managed": true,
+  "overriddenProperties": [],
+  "parent": {
+    "name": "Objetos",
+    "path": "folders/Objetos.yy",
+  },
+  "parentObjectId": null,
+  "persistent": false,
+  "physicsAngularDamping": 0.1,
+  "physicsDensity": 0.5,
+  "physicsFriction": 0.2,
+  "physicsGroup": 1,
+  "physicsKinematic": false,
+  "physicsLinearDamping": 0.1,
+  "physicsObject": false,
+  "physicsRestitution": 0.1,
+  "physicsSensor": false,
+  "physicsShape": 1,
+  "physicsShapePoints": [],
+  "physicsStartAwake": true,
+  "properties": [],
+  "solid": false,
+  "spriteId": null,
+  "spriteMaskId": null,
+  "visible": true,
+}

--- a/objects/BrickBase/Create_0.gml
+++ b/objects/BrickBase/Create_0.gml
@@ -1,0 +1,5 @@
+/// @description Inicializa el ladrillo base
+// Función que se ejecuta al ser golpeado desde abajo
+onHit = function() {
+    // Esta función será sobreescrita por los hijos
+};

--- a/objects/Player/Step_0.gml
+++ b/objects/Player/Step_0.gml
@@ -79,7 +79,7 @@ if (vsp > 15) {
 }
 
 // Colisión horizontal
-if (place_meeting(x + hsp, y, Solid)) {
+if (place_meeting(x + hsp, y, Solid) || place_meeting(x + hsp, y, BrickBase)) {
     hsp = 0;
 }
 x += hsp;
@@ -177,7 +177,7 @@ for (var i = 0; i < _steps; i++) {
 }
 
 // Si no está en el suelo, actualizar on_ground
-if (!place_meeting(x, y + 1, Solid) && !place_meeting(x, y + 1, SemiSolid) && !place_meeting(x, y + 1, EnemyCarrier)) {
+if (!place_meeting(x, y + 1, Solid) && !place_meeting(x, y + 1, SemiSolid) && !place_meeting(x, y + 1, EnemyCarrier) && !place_meeting(x, y + 1, BrickBase)) {
     on_ground = false;
 }
 

--- a/objects/Player/Step_0.gml
+++ b/objects/Player/Step_0.gml
@@ -109,6 +109,22 @@ for (var i = 0; i < _steps; i++) {
         }
         break;
     }
+
+    // Verificar colisión con ladrillos
+    var _brick = instance_place(x, y + _vsp_sign, BrickBase);
+    if (_brick != noone) {
+        if (_vsp_sign < 0) {
+            if (is_undefined(_brick.onHit) == false) {
+                _brick.onHit();
+            }
+            vsp = 0;
+        } else {
+            on_ground = true;
+            vsp = 0;
+            y = _brick.y - sprite_height;
+        }
+        break;
+    }
     
     // Verificar colisión con SemiSolid
     if (place_meeting(x, y + _vsp_sign, SemiSolid)) {


### PR DESCRIPTION
## Summary
- create `BrickBase` to handle being hit from below
- create `BlockBrick` inheriting from `BrickBase` using `spr_block_brick`
- let player interact with brick objects when jumping up

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68612026e734832ebf10af424e4df2f1